### PR TITLE
Fix: Solana Kit 3 type issues

### DIFF
--- a/src/lib/connect.ts
+++ b/src/lib/connect.ts
@@ -308,7 +308,7 @@ export interface Connection {
    * Builds, signs and sends a transaction containing multiple instructions.
    * @param {Object} params - Transaction parameters
    * @param {KeyPairSigner} params.feePayer - Account that will pay the transaction fees
-   * @param {Array<IInstruction>} params.instructions - List of instructions to execute in sequence
+   * @param {Array<Instruction>} params.instructions - List of instructions to execute in sequence
    * @param {Commitment} [params.commitment="confirmed"] - Confirmation level to wait for:
    *                                                      'processed' = processed by current node,
    *                                                      'confirmed' = confirmed by supermajority of the cluster,
@@ -569,7 +569,7 @@ export interface Connection {
    * Builds, signs and sends a transaction containing multiple instructions using a wallet app.
    * @param {Object} params - Transaction parameters
    * @param {TransactionSendingSigner} params.feePayer - Account that will pay the transaction fees
-   * @param {Array<IInstruction>} params.instructions - List of instructions to execute in sequence
+   * @param {Array<Instruction>} params.instructions - List of instructions to execute in sequence
    * @param {AbortSignal | null} [params.abortSignal=null] - Signal to cancel the transaction
    * @returns {Promise<string>} The transaction signature
    */

--- a/src/lib/smart-transactions.ts
+++ b/src/lib/smart-transactions.ts
@@ -6,7 +6,7 @@ import {
   TransactionMessage,
   isWritableRole,
   isInstructionWithData,
-  CompilableTransactionMessage,
+  TransactionMessageWithFeePayer,
   createSolanaRpcFromTransport,
   sendAndConfirmTransactionFactory,
   TransactionWithBlockhashLifetime,
@@ -15,6 +15,8 @@ import {
   SOLANA_ERROR__TRANSACTION_ERROR__ALREADY_PROCESSED,
   isSolanaError,
   SOLANA_ERROR__JSON_RPC__SERVER_ERROR_SEND_TRANSACTION_PREFLIGHT_FAILURE,
+  assertIsTransactionWithinSizeLimit,
+  Transaction,
 } from "@solana/kit";
 import {
   getSetComputeUnitPriceInstruction,
@@ -78,7 +80,7 @@ export const getPriorityFeeEstimate = async (
 
 export const getComputeUnitEstimate = async (
   rpc: ReturnType<typeof createSolanaRpcFromTransport>,
-  transactionMessage: CompilableTransactionMessage,
+  transactionMessage: TransactionMessage & TransactionMessageWithFeePayer,
   abortSignal: AbortSignal | null = null,
 ) => {
   // add placeholder instruction for CU price if not already present
@@ -105,7 +107,7 @@ export const getComputeUnitEstimate = async (
 
 export const sendTransactionWithRetries = async (
   sendAndConfirmTransaction: ReturnType<typeof sendAndConfirmTransactionFactory>,
-  transaction: FullySignedTransaction & TransactionWithBlockhashLifetime,
+  transaction: Transaction & FullySignedTransaction & TransactionWithBlockhashLifetime,
   options: {
     maximumClientSideRetries: number;
     abortSignal: AbortSignal | null;
@@ -158,6 +160,7 @@ export const sendTransactionWithRetries = async (
 
   while (retriesLeft) {
     try {
+      assertIsTransactionWithinSizeLimit(transaction);
       const txPromise = sendAndConfirmTransaction(transaction, transactionOptions);
       await getAbortablePromise(txPromise, AbortSignal.timeout(timeout));
       break;

--- a/src/lib/transactions.ts
+++ b/src/lib/transactions.ts
@@ -1,6 +1,7 @@
 import {
   appendTransactionMessageInstructions,
   assertIsTransactionMessageWithSingleSendingSigner,
+  assertIsTransactionWithinSizeLimit,
   Commitment,
   createSolanaRpcFromTransport,
   createTransactionMessage,
@@ -132,6 +133,7 @@ export const sendTransactionFromInstructionsFactory = (
     assertIsTransactionMessageWithBlockhashLifetime(transactionMessage);
 
     const signedTransaction = await signTransactionMessageWithSigners(transactionMessage);
+    assertIsTransactionWithinSizeLimit(signedTransaction);
 
     const signature = getSignatureFromTransaction(signedTransaction);
 

--- a/src/tests/logs.test.ts
+++ b/src/tests/logs.test.ts
@@ -9,7 +9,7 @@ describe("getLogs", () => {
     const connection = connect();
     const keyPairSigner = await generateKeyPairSigner();
 
-    const signature = await connection.airdropIfRequired(keyPairSigner.address, lamports(2n * SOL), lamports(1n * SOL));
+    const signature = await connection.airdropIfRequired(keyPairSigner.address, lamports(2n * SOL), lamports(1n * SOL), null);
 
     // Signature should never be null as we always need an airdrop
     assert.ok(signature);

--- a/src/tests/sol.test.ts
+++ b/src/tests/sol.test.ts
@@ -15,7 +15,7 @@ describe("getLamportBalance", () => {
   test("getLamportBalance returns 1 SOL after 1 SOL is airdropped", async () => {
     const keypairSigner = await generateKeyPairSigner();
     const connection = connect();
-    await connection.airdropIfRequired(keypairSigner.address, lamports(1n * SOL), lamports(1n * SOL));
+    await connection.airdropIfRequired(keypairSigner.address, lamports(1n * SOL), lamports(1n * SOL), null);
     const balance = await connection.getLamportBalance(keypairSigner.address, "finalized");
     assert.equal(balance, lamports(1n * SOL));
   });


### PR DESCRIPTION
Fixing a couple errors when running `buiild`: 
- assert transaction size in limits
- remove dupe mint fetch using both token programs (token22 fetch is backwards compatible). this avoids a type error
- got rid of one last instance of IInstruction

fixing before updating CI in #7 