### PR TITLE
added QuickNode Priority Fee API and Metaplex DAS helpers

### DIFF
--- a/logs.txt
+++ b/logs.txt
@@ -1,0 +1,1107 @@
+
+> solana-kite@3.2.1 test
+> npx tsx --test --test-concurrency=true src/tests/*
+
+▶ connect
+  [32m✔ connect returns a connection object [90m(10.734804ms)[39m[39m
+  [32m✔ connect throws an error connecting to a cluster that requires an API key when the API key is not set [90m(1.421248ms)[39m[39m
+  [32m✔ connect returns a connection object with the correct URLs when two custom URLs are provided [90m(2.45586ms)[39m[39m
+  [32m✔ connect returns a connection object when connecting to a cluster that requires an API key when the API key is set [90m(1.073317ms)[39m[39m
+  [32m✔ connect returns a connection object with the correct URLs when a cluster name is provided [90m(0.985878ms)[39m[39m
+  [32m✔ connect throws an error when an invalid cluster name is provided [90m(0.72723ms)[39m[39m
+  [32m✔ connect throws an error when Quicknode cluster is used without environment variable [90m(0.619503ms)[39m[39m
+  [32m✔ connect works with Quicknode when environment variable is set [90m(1.998739ms)[39m[39m
+  [32m✔ connect throws an error when Triton cluster is used without environment variable [90m(1.067526ms)[39m[39m
+  [32m✔ connect works with Triton when environment variable is set [90m(3.246793ms)[39m[39m
+  ▶ with RPC and RPC subscriptions clients
+    [32m✔ connect accepts RPC and RPC subscriptions clients directly [90m(1.325082ms)[39m[39m
+    [32m✔ connect throws error when RPC client is provided without RPC subscriptions client [90m(0.98628ms)[39m[39m
+    [32m✔ connect throws error when RPC client is provided with string as second argument [90m(0.683917ms)[39m[39m
+    [32m✔ connection with custom RPC clients can perform basic operations [90m(456.496136ms)[39m[39m
+  [32m✔ with RPC and RPC subscriptions clients [90m(460.589188ms)[39m[39m
+[32m✔ connect [90m(489.871825ms)[39m[39m
+▶ getLogs
+  [31m✖ getLogs works [90m(25.293376ms)[39m[39m
+[31m✖ getLogs [90m(40.098981ms)[39m[39m
+▶ getWebsocketUrlFromHTTPUrl
+  [32m✔ converts http to ws [90m(0.807113ms)[39m[39m
+  [32m✔ converts https to wss [90m(0.224612ms)[39m[39m
+  [32m✔ throws on non-http(s) url [90m(0.440968ms)[39m[39m
+  [32m✔ throws on invalid url [90m(0.477659ms)[39m[39m
+[32m✔ getWebsocketUrlFromHTTPUrl [90m(4.767299ms)[39m[39m
+▶ getCustomErrorMessage
+  [32m✔ we turn error messages with hex codes into error messages for the program [90m(11.090309ms)[39m[39m
+[32m✔ getCustomErrorMessage [90m(20.38244ms)[39m[39m
+▶ getErrorMessageFromLogs
+  [32m✔ extracts error message with program and instruction name [90m(10.610333ms)[39m[39m
+  [32m✔ returns null when no error message found [90m(0.543418ms)[39m[39m
+  [32m✔ returns null when program invoke log is missing [90m(0.380484ms)[39m[39m
+  [32m✔ returns null when instruction log is missing [90m(0.277315ms)[39m[39m
+  [32m✔ extracts Anchor error message with program and instruction name [90m(0.306822ms)[39m[39m
+  [32m✔ extracts system program error message with program and instruction name [90m(1.734756ms)[39m[39m
+[32m✔ getErrorMessageFromLogs [90m(17.910983ms)[39m[39m
+▶ getExplorerLink
+  [32m✔ getExplorerLink works for a block on mainnet [90m(19.94364ms)[39m[39m
+  [32m✔ getExplorerLink works for an address using helius-mainnet [90m(1.652993ms)[39m[39m
+  [32m✔ getExplorerLink works for an address on localnet when no network is supplied [90m(1.171176ms)[39m[39m
+  [32m✔ getExplorerLink works for an address on mainnet-beta [90m(0.654882ms)[39m[39m
+  [32m✔ getExplorerLink works for an address on devnet [90m(0.690079ms)[39m[39m
+  [32m✔ getExplorerLink works for a transaction on mainnet-beta [90m(0.723464ms)[39m[39m
+  [32m✔ getExplorerLink works for a block on mainnet-beta [90m(1.55799ms)[39m[39m
+  [32m✔ getExplorerLink provides a localnet URL [90m(1.159894ms)[39m[39m
+[32m✔ getExplorerLink [90m(34.650564ms)[39m[39m
+▶ bytesToCryptoKeyPair
+  [32m✔ converts a byte array to a keyPairSigner and back [90m(42.514149ms)[39m[39m
+[32m✔ bytesToCryptoKeyPair [90m(46.732974ms)[39m[39m
+▶ addKeyPairSignerToEnvFile
+  [32m✔ Adds keyPairSigner to env file if variable doesn't exist [90m(21.507712ms)[39m[39m
+  [32m✔ throws a nice error if the env var already exists [90m(1.521791ms)[39m[39m
+[32m✔ addKeyPairSignerToEnvFile [90m(35.985646ms)[39m[39m
+▶ loadWalletFromFile
+  [32m✔ getting a keyPair from a file [90m(47.458221ms)[39m[39m
+  [32m✔ throws a nice error if the file is missing [90m(7.474475ms)[39m[39m
+  [32m✔ throws a nice error if the file is corrupt [90m(11.749568ms)[39m[39m
+[32m✔ loadWalletFromFile [90m(68.327944ms)[39m[39m
+▶ loadWalletFromEnvironment
+  [32m✔ getting a keyPair from an environment variable (array of numbers format) [90m(6.91628ms)[39m[39m
+  [32m✔ throws a nice error if the env var doesn't exist [90m(1.580083ms)[39m[39m
+  [32m✔ throws a nice error if the value of the env var isn't valid [90m(1.035795ms)[39m[39m
+[32m✔ loadWalletFromEnvironment [90m(21.90616ms)[39m[39m
+▶ checkAddressMatchesPrivateKey
+  [32m✔ returns true when address matches secret key [90m(17.89799ms)[39m[39m
+  [32m✔ returns false when address does not match secret key [90m(13.420076ms)[39m[39m
+[32m✔ checkAddressMatchesPrivateKey [90m(32.182761ms)[39m[39m
+▶ checkIfAddressIsPublicKey
+  [32m✔ returns true for valid Ed25519 public key bytes [90m(3.337658ms)[39m[39m
+  [32m✔ returns true for valid base58 encoded public key [90m(2.118079ms)[39m[39m
+  [32m✔ returns false for a Program Derived Address [90m(13.158292ms)[39m[39m
+  [32m✔ returns true for valid Address type [90m(4.378543ms)[39m[39m
+  [32m✔ returns false for invalid length bytes [90m(0.748582ms)[39m[39m
+  [32m✔ returns false for invalid base58 string [90m(1.753617ms)[39m[39m
+  [32m✔ returns false for invalid public key bytes [90m(0.442893ms)[39m[39m
+  [32m✔ returns false for non-base58 string [90m(0.631015ms)[39m[39m
+  [32m✔ returns false for empty string [90m(0.317241ms)[39m[39m
+  [32m✔ returns false for null [90m(0.182862ms)[39m[39m
+  [32m✔ returns false for undefined [90m(0.141132ms)[39m[39m
+[32m✔ checkIfAddressIsPublicKey [90m(35.186256ms)[39m[39m
+▶ getLogs
+  [31m✖ getLogs works [90m(69.158734ms)[39m[39m
+[31m✖ getLogs [90m(109.634417ms)[39m[39m
+▶ getPDAAndBump
+  [32m✔ getPDAAndBump returns the same as the web3.js v1 equivalent code [90m(29.296947ms)[39m[39m
+  [32m✔ works with string seed only [90m(6.336795ms)[39m[39m
+  [32m✔ works with Address seed only [90m(8.560387ms)[39m[39m
+  [32m✔ works with BigInt seed only [90m(5.132806ms)[39m[39m
+  [32m✔ works with Uint8Array seed only [90m(8.729462ms)[39m[39m
+  [32m✔ works with mixed seed types [90m(5.88819ms)[39m[39m
+  [32m✔ throws or returns for empty seeds array [90m(7.604446ms)[39m[39m
+  [32m✔ useBigEndian parameter works with BigInt seeds [90m(4.490238ms)[39m[39m
+  [32m✔ useBigEndian parameter defaults to false (little-endian) [90m(8.843482ms)[39m[39m
+  [32m✔ useBigEndian parameter works with mixed seed types [90m(17.619584ms)[39m[39m
+  [32m✔ useBigEndian parameter only affects BigInt seeds [90m(8.354029ms)[39m[39m
+[32m✔ getPDAAndBump [90m(122.855126ms)[39m[39m
+Skipping live test — set QN_ENDPOINT_URL to run
+Skipping live test — set QN_ENDPOINT_URL to run
+▶ getQuickNodePriorityFeesFactory
+  [32m✔ factory returns a function [90m(2.641154ms)[39m[39m
+  [32m✔ returns all fee levels and networkCongestion when endpoint is live [90m(2.709506ms)[39m[39m
+  [32m✔ accepts account filter option [90m(0.681143ms)[39m[39m
+  [32m✔ throws on HTTP error from endpoint [90m(153.369576ms)[39m[39m
+Skipping live test — set QN_ENDPOINT_URL to run
+Skipping live test — set QN_ENDPOINT_URL to run
+Skipping live test — set QN_ENDPOINT_URL to run
+  [32m✔ throws on RPC method error [90m(53.478141ms)[39m[39m
+[32m✔ getQuickNodePriorityFeesFactory [90m(215.995328ms)[39m[39m
+▶ getAssetsByOwnerFactory
+  [32m✔ factory returns a function [90m(0.709398ms)[39m[39m
+  [32m✔ returns assets result shape when endpoint is live [90m(1.390862ms)[39m[39m
+  [32m✔ respects limit option [90m(6.321342ms)[39m[39m
+  [32m✔ returns empty items for wallet with no NFTs [90m(1.187239ms)[39m[39m
+Skipping live test — set QN_ENDPOINT_URL to run
+Skipping live test — set QN_ENDPOINT_URL to run
+  [32m✔ throws on HTTP error from endpoint [90m(59.485356ms)[39m[39m
+[32m✔ getAssetsByOwnerFactory [90m(77.805559ms)[39m[39m
+▶ getAssetFactory
+  [32m✔ factory returns a function [90m(0.603084ms)[39m[39m
+  [32m✔ returns full asset details for a known mint [90m(7.141243ms)[39m[39m
+  [32m✔ asset has correct compression fields for a cNFT [90m(1.181519ms)[39m[39m
+  [32m✔ throws on HTTP error from endpoint [90m(47.772767ms)[39m[39m
+  [32m✔ throws on RPC error response [90m(43.492822ms)[39m[39m
+[32m✔ getAssetFactory [90m(101.3405ms)[39m[39m
+▶ rpc
+  [31m✖ getLatestBlockhash returns a valid blockhash[39m
+  [31m✖ checkHealth returns cluster health[39m
+  [31m✖ getCurrentSlot returns a valid slot number[39m
+  [31m✖ getMinimumBalance calculates rent for given data size[39m
+  [31m✖ getMinimumBalance calculates higher rent for larger data sizes[39m
+  [31m✖ getTransaction returns transaction details for valid signature[39m
+  [31m✖ getTransaction returns null for invalid signature[39m
+[31m✖ rpc [90m(90.82404ms)[39m[39m
+▶ Smart transactions
+  [90m﹣ transferLamports on mainnet with retries [90m(1.631682ms)[39m # skipping mainnet tests unless explicitly needed[39m
+[32m✔ Smart transactions [90m(4.030302ms)[39m[39m
+▶ getLamportBalance
+  [31m✖ getLamportBalance returns 0 for a new account [90m(99.43322ms)[39m[39m
+  [31m✖ getLamportBalance returns 1 SOL after 1 SOL is airdropped [90m(47.713693ms)[39m[39m
+[31m✖ getLamportBalance [90m(154.01423ms)[39m[39m
+▶ transferLamports
+  [31m✖ Transferring SOL / lamports between wallets [90m(40.108165ms)[39m[39m
+[31m✖ transferLamports [90m(46.550562ms)[39m[39m
+▶ airdropIfRequired error handling
+  [32m✔ airdropIfRequired throws helpful error when HTTP server returns 429 Too Many Requests [90m(122.36696ms)[39m[39m
+[32m✔ airdropIfRequired error handling [90m(123.548735ms)[39m[39m
+▶ watchLamportBalance
+  [31m✖ watchLamportBalance calls callback with initial balance [90m(21.595421ms)[39m[39m
+  [31m✖ watchLamportBalance calls callback when balance changes [90m(22.246134ms)[39m[39m
+  [31m✖ watchLamportBalance cleanup prevents further callbacks [90m(35.348558ms)[39m[39m
+  [32m✔ watchLamportBalance handles errors appropriately [90m(21.751912ms)[39m[39m
+[31m✖ watchLamportBalance [90m(103.090734ms)[39m[39m
+▶ tokens
+  [90m﹣ We can make a new token mint with one additional metadata field # SKIP[39m
+  [90m﹣ We can make a new token mint with two additional metadata fields # SKIP[39m
+  [90m﹣ We can make a new token mint without additional metadata # SKIP[39m
+  [31m✖ We cannot use Token Extensions without providing a name[39m
+  [31m✖ We cannot use Token Extensions without providing a symbol[39m
+  [31m✖ We cannot use Token Extensions without providing a uri[39m
+  [31m✖ The mint authority can mintTokens[39m
+  [31m✖ We can get the mint[39m
+  [31m✖ transferTokens transfers tokens from one account to another[39m
+  [31m✖ getTokenAccountBalance returns the correct balance using wallet and mint[39m
+  [31m✖ getTokenAccountBalance returns the correct balance using direct token account[39m
+  [31m✖ getTokenAccountBalance throws error when neither tokenAccount nor wallet+mint provided[39m
+  [31m✖ checkTokenAccountIsClosed returns false for an open token account[39m
+  [31m✖ checkTokenAccountIsClosed returns false when using wallet and mint for an open account[39m
+  [31m✖ checkTokenAccountIsClosed returns true for a non-existent token account[39m
+  [31m✖ checkTokenAccountIsClosed throws error when neither tokenAccount nor wallet+mint provided[39m
+  [31m✖ burnTokens burns tokens from an account[39m
+  [31m✖ burnTokens throws error when mint not found[39m
+  [31m✖ closeTokenAccount closes an account with zero balance[39m
+  [31m✖ closeTokenAccount throws error when neither tokenAccount nor wallet+mint provided[39m
+  [31m✖ getTokenAccounts returns token accounts from both classic and token extensions programs[39m
+  [31m✖ getTokenAccounts returns accounts after minting tokens[39m
+  [31m✖ getTokenAccounts with excludeZeroBalance filters out empty accounts[39m
+[31m✖ tokens [90m(37.131835ms)[39m[39m
+▶ createTokenMint
+  [31m✖ createTokenMint makes a new mint with the specified metadata [90m(20.481532ms)[39m[39m
+[31m✖ createTokenMint [90m(21.129247ms)[39m[39m
+▶ getTokenAccountAddress
+  [32m✔ getTokenAccountAddress returns the correct token account address for a classic Token program token [90m(3.391553ms)[39m[39m
+  [32m✔ getTokenAccountAddress returns the correct token account address for a Token Extensions token [90m(2.694442ms)[39m[39m
+[32m✔ getTokenAccountAddress [90m(6.393006ms)[39m[39m
+▶ getTokenMetadata
+  [31m✖ getTokenMetadata retrieves metadata for a token with metadata pointer extension [90m(3.624511ms)[39m[39m
+[31m✖ getTokenMetadata [90m(4.090918ms)[39m[39m
+▶ classic token program
+  [31m✖ We can make tokens using the classic token program[39m
+  [31m✖ The mint authority can mintTokens using the classic token program[39m
+  [31m✖ We can get the mint using (for a mint using the classic token program)[39m
+  [31m✖ transferTokens transfers tokens from one account to another using the classic token program[39m
+  [31m✖ getTokenAccountBalance returns the correct balance using wallet and mint[39m
+  [31m✖ getTokenAccountBalance returns the correct balance using direct token account[39m
+  [31m✖ checkTokenAccountIsClosed returns false for an open token account[39m
+  [31m✖ checkTokenAccountIsClosed returns false when using wallet and mint for an open account[39m
+  [31m✖ checkTokenAccountIsClosed returns true for a non-existent token account[39m
+  [31m✖ cannot get metadata for a mint using the classic token program[39m
+[31m✖ classic token program [90m(4.655283ms)[39m[39m
+▶ watchTokenBalance
+  [31m✖ watchTokenBalance calls callback with initial balance [90m(8.475972ms)[39m[39m
+  [31m✖ watchTokenBalance calls callback when balance changes [90m(7.476189ms)[39m[39m
+  [31m✖ watchTokenBalance cleanup prevents further callbacks [90m(5.499898ms)[39m[39m
+  [32m✔ watchTokenBalance handles errors appropriately [90m(2.398954ms)[39m[39m
+[31m✖ watchTokenBalance [90m(24.417842ms)[39m[39m
+[90m﹣ updateTokenMetadata [90m(0.225544ms)[39m # SKIP[39m
+▶ Send Transaction From Instructions
+  [31m✖ should send transaction from instructions without client side retries (processed commitment)[39m
+  [31m✖ should send transaction from instructions with client side retries (processed commitment)[39m
+  [31m✖ should send transaction from instructions without client side retries (default commitment-confirmed)[39m
+  [31m✖ should send transaction from instructions with client side retries (default commitment-confirmed)[39m
+  [31m✖ should send transaction from instructions without client side retries (finalized commitment)[39m
+  [31m✖ should send transaction from instructions with client side retries (finalized commitment)[39m
+[31m✖ Send Transaction From Instructions [90m(35.61088ms)[39m[39m
+▶ createWallet
+  [31m✖ createWallet generates a new keyPair with a SOL balance [90m(32.281636ms)[39m[39m
+  [31m✖ createWallet generates a new keyPair with a SOL balance with a commitment [90m(9.715335ms)[39m[39m
+  ▶ with prefix and suffix
+    [31m✖ creates a wallet with a prefix [90m(84.452066ms)[39m[39m
+    [31m✖ creates a wallet with a suffix [90m(284.413428ms)[39m[39m
+    [31m✖ creates a wallet with both prefix and suffix [90m(150.706371ms)[39m[39m
+    [32m✔ throws error for invalid prefix characters [90m(1.221118ms)[39m[39m
+    [32m✔ throws error for invalid suffix characters [90m(0.202219ms)[39m[39m
+  [31m✖ with prefix and suffix [90m(521.51936ms)[39m[39m
+  ▶ with fileName
+    [31m✖ creates a wallet and saves it to a JSON file [90m(7.189227ms)[39m[39m
+    [32m✔ throws error if file already exists [90m(2.005467ms)[39m[39m
+    [32m✔ throws error if both fileName and envFileName are provided [90m(0.391583ms)[39m[39m
+  [31m✖ with fileName [90m(9.954645ms)[39m[39m
+[31m✖ createWallet [90m(574.663651ms)[39m[39m
+▶ airdropIfRequired
+  [31m✖ Checking the balance after airdropIfRequired [90m(4.326982ms)[39m[39m
+  [31m✖ Checking the balance after airdropIfRequired with a commitment [90m(4.068225ms)[39m[39m
+  [31m✖ airdropIfRequired doesn't request unnecessary airdrops [90m(2.561346ms)[39m[39m
+  [31m✖ airdropIfRequired does airdrop when necessary [90m(2.905498ms)[39m[39m
+[31m✖ airdropIfRequired [90m(14.425644ms)[39m[39m
+▶ createWallets
+  [31m✖ creates multiple wallets with the same options [90m(4.103292ms)[39m[39m
+  [31m✖ creates multiple wallets with just a number parameter [90m(3.955016ms)[39m[39m
+[31m✖ createWallets [90m(8.507753ms)[39m[39m
+[34mℹ tests 162[39m
+[34mℹ suites 37[39m
+[34mℹ pass 90[39m
+[34mℹ fail 25[39m
+[34mℹ cancelled 43[39m
+[34mℹ skipped 4[39m
+[34mℹ todo 0[39m
+[34mℹ duration_ms 3825.308005[39m
+
+[31m✖ failing tests:[39m
+
+test at src/tests/connect.test.ts:1:4008
+[31m✖ getLogs works [90m(25.293376ms)[39m[39m
+  TypeError: fetch failed
+      at node:internal/deps/undici/undici:15845:13
+      at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
+      at async makeHttpRequest (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc-transport-http/src/http-transport.ts:69:26)
+      at async <anonymous> (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc/src/rpc-request-coalescer.ts:53:28)
+      at async makeCoalescedHttpRequest (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc/src/rpc-request-coalescer.ts:99:21)
+      at async Object.execute (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc-spec/src/rpc-api.ts:126:42)
+      at async Object.send (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc-spec/src/rpc.ts:100:20)
+      at async getLamportBalance (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/src/lib/sol.ts:23:39)
+      at async Object.airdropIfRequired (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/src/lib/sol.ts:78:21)
+      at async TestContext.<anonymous> (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/src/tests/connect.test.ts:140:23) {
+    [cause]: Error: connect ECONNREFUSED 127.0.0.1:8899
+        at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1637:16) {
+      errno: -111,
+      code: 'ECONNREFUSED',
+      syscall: 'connect',
+      address: '127.0.0.1',
+      port: 8899
+    }
+  }
+
+test at src/tests/logs.test.ts:1:208
+[31m✖ getLogs works [90m(69.158734ms)[39m[39m
+  TypeError: fetch failed
+      at node:internal/deps/undici/undici:15845:13
+      at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
+      at async makeHttpRequest (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc-transport-http/src/http-transport.ts:69:26)
+      at async <anonymous> (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc/src/rpc-request-coalescer.ts:53:28)
+      at async makeCoalescedHttpRequest (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc/src/rpc-request-coalescer.ts:99:21)
+      at async Object.execute (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc-spec/src/rpc-api.ts:126:42)
+      at async Object.send (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc-spec/src/rpc.ts:100:20)
+      at async getLamportBalance (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/src/lib/sol.ts:23:39)
+      at async Object.airdropIfRequired (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/src/lib/sol.ts:78:21)
+      at async TestContext.<anonymous> (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/src/tests/logs.test.ts:12:23) {
+    [cause]: Error: connect ECONNREFUSED 127.0.0.1:8899
+        at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1637:16) {
+      errno: -111,
+      code: 'ECONNREFUSED',
+      syscall: 'connect',
+      address: '127.0.0.1',
+      port: 8899
+    }
+  }
+
+test at src/tests/rpc.test.ts:1:349
+[31m✖ getLatestBlockhash returns a valid blockhash[39m
+  'test did not finish before its parent and was cancelled'
+
+test at src/tests/rpc.test.ts:1:593
+[31m✖ checkHealth returns cluster health[39m
+  'test did not finish before its parent and was cancelled'
+
+test at src/tests/rpc.test.ts:1:734
+[31m✖ getCurrentSlot returns a valid slot number[39m
+  'test did not finish before its parent and was cancelled'
+
+test at src/tests/rpc.test.ts:1:895
+[31m✖ getMinimumBalance calculates rent for given data size[39m
+  'test did not finish before its parent and was cancelled'
+
+test at src/tests/rpc.test.ts:1:1097
+[31m✖ getMinimumBalance calculates higher rent for larger data sizes[39m
+  'test did not finish before its parent and was cancelled'
+
+test at src/tests/rpc.test.ts:1:1377
+[31m✖ getTransaction returns transaction details for valid signature[39m
+  'test did not finish before its parent and was cancelled'
+
+test at src/tests/rpc.test.ts:1:1699
+[31m✖ getTransaction returns null for invalid signature[39m
+  'test did not finish before its parent and was cancelled'
+
+test at src/tests/rpc.test.ts:1:169
+[31m✖ rpc [90m(90.82404ms)[39m[39m
+  TypeError: fetch failed
+      at node:internal/deps/undici/undici:15845:13
+      at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
+      at async makeHttpRequest (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc-transport-http/src/http-transport.ts:69:26)
+      at async <anonymous> (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc/src/rpc-request-coalescer.ts:53:28)
+      at async makeCoalescedHttpRequest (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc/src/rpc-request-coalescer.ts:99:21)
+      at async Object.execute (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc-spec/src/rpc-api.ts:126:42)
+      at async Object.send (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc-spec/src/rpc.ts:100:20)
+      at async getLamportBalance (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/src/lib/sol.ts:23:39)
+      at async airdropIfRequired (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/src/lib/sol.ts:78:21)
+      at async Object.createWallet (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/src/lib/wallets.ts:131:7) {
+    [cause]: Error: connect ECONNREFUSED 127.0.0.1:8899
+        at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1637:16) {
+      errno: -111,
+      code: 'ECONNREFUSED',
+      syscall: 'connect',
+      address: '127.0.0.1',
+      port: 8899
+    }
+  }
+
+test at src/tests/sol.test.ts:1:412
+[31m✖ getLamportBalance returns 0 for a new account [90m(99.43322ms)[39m[39m
+  TypeError: fetch failed
+      at node:internal/deps/undici/undici:15845:13
+      at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
+      at async makeHttpRequest (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc-transport-http/src/http-transport.ts:69:26)
+      at async <anonymous> (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc/src/rpc-request-coalescer.ts:53:28)
+      at async makeCoalescedHttpRequest (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc/src/rpc-request-coalescer.ts:99:21)
+      at async Object.execute (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc-spec/src/rpc-api.ts:126:42)
+      at async Object.send (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc-spec/src/rpc.ts:100:20)
+      at async Object.getLamportBalance (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/src/lib/sol.ts:23:39)
+      at async TestContext.<anonymous> (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/src/tests/sol.test.ts:18:21)
+      at async Test.run (node:internal/test_runner/test:1113:7) {
+    [cause]: Error: connect ECONNREFUSED 127.0.0.1:8899
+        at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1637:16) {
+      errno: -111,
+      code: 'ECONNREFUSED',
+      syscall: 'connect',
+      address: '127.0.0.1',
+      port: 8899
+    }
+  }
+
+test at src/tests/sol.test.ts:1:663
+[31m✖ getLamportBalance returns 1 SOL after 1 SOL is airdropped [90m(47.713693ms)[39m[39m
+  TypeError: fetch failed
+      at node:internal/deps/undici/undici:15845:13
+      at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
+      at async makeHttpRequest (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc-transport-http/src/http-transport.ts:69:26)
+      at async <anonymous> (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc/src/rpc-request-coalescer.ts:53:28)
+      at async makeCoalescedHttpRequest (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc/src/rpc-request-coalescer.ts:99:21)
+      at async Object.execute (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc-spec/src/rpc-api.ts:126:42)
+      at async Object.send (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc-spec/src/rpc.ts:100:20)
+      at async getLamportBalance (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/src/lib/sol.ts:23:39)
+      at async Object.airdropIfRequired (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/src/lib/sol.ts:78:21)
+      at async TestContext.<anonymous> (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/src/tests/sol.test.ts:25:5) {
+    [cause]: Error: connect ECONNREFUSED 127.0.0.1:8899
+        at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1637:16) {
+      errno: -111,
+      code: 'ECONNREFUSED',
+      syscall: 'connect',
+      address: '127.0.0.1',
+      port: 8899
+    }
+  }
+
+test at src/tests/sol.test.ts:1:1067
+[31m✖ Transferring SOL / lamports between wallets [90m(40.108165ms)[39m[39m
+  TypeError: fetch failed
+      at node:internal/deps/undici/undici:15845:13
+      at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
+      at async makeHttpRequest (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc-transport-http/src/http-transport.ts:69:26)
+      at async <anonymous> (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc/src/rpc-request-coalescer.ts:53:28)
+      at async makeCoalescedHttpRequest (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc/src/rpc-request-coalescer.ts:99:21)
+      at async Object.execute (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc-spec/src/rpc-api.ts:126:42)
+      at async Object.send (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc-spec/src/rpc.ts:100:20)
+      at async getLamportBalance (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/src/lib/sol.ts:23:39)
+      at async airdropIfRequired (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/src/lib/sol.ts:78:21)
+      at async createWallet (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/src/lib/wallets.ts:131:7) {
+    [cause]: Error: connect ECONNREFUSED 127.0.0.1:8899
+        at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1637:16) {
+      errno: -111,
+      code: 'ECONNREFUSED',
+      syscall: 'connect',
+      address: '127.0.0.1',
+      port: 8899
+    }
+  }
+
+test at src/tests/sol.test.ts:1:2758
+[31m✖ watchLamportBalance calls callback with initial balance [90m(21.595421ms)[39m[39m
+  TypeError: fetch failed
+      at node:internal/deps/undici/undici:15845:13
+      at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
+      at async makeHttpRequest (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc-transport-http/src/http-transport.ts:69:26)
+      at async <anonymous> (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc/src/rpc-request-coalescer.ts:53:28)
+      at async makeCoalescedHttpRequest (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc/src/rpc-request-coalescer.ts:99:21)
+      at async Object.execute (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc-spec/src/rpc-api.ts:126:42)
+      at async Object.send (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc-spec/src/rpc.ts:100:20)
+      at async getLamportBalance (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/src/lib/sol.ts:23:39)
+      at async Object.airdropIfRequired (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/src/lib/sol.ts:78:21)
+      at async TestContext.<anonymous> (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/src/tests/sol.test.ts:114:5) {
+    [cause]: Error: connect ECONNREFUSED 127.0.0.1:8899
+        at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1637:16) {
+      errno: -111,
+      code: 'ECONNREFUSED',
+      syscall: 'connect',
+      address: '127.0.0.1',
+      port: 8899
+    }
+  }
+
+test at src/tests/sol.test.ts:1:3208
+[31m✖ watchLamportBalance calls callback when balance changes [90m(22.246134ms)[39m[39m
+  TypeError: fetch failed
+      at node:internal/deps/undici/undici:15845:13
+      at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
+      at async makeHttpRequest (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc-transport-http/src/http-transport.ts:69:26)
+      at async <anonymous> (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc/src/rpc-request-coalescer.ts:53:28)
+      at async makeCoalescedHttpRequest (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc/src/rpc-request-coalescer.ts:99:21)
+      at async Object.execute (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc-spec/src/rpc-api.ts:126:42)
+      at async Object.send (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc-spec/src/rpc.ts:100:20)
+      at async getLamportBalance (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/src/lib/sol.ts:23:39)
+      at async airdropIfRequired (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/src/lib/sol.ts:78:21)
+      at async createWallet (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/src/lib/wallets.ts:131:7) {
+    [cause]: Error: connect ECONNREFUSED 127.0.0.1:8899
+        at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1637:16) {
+      errno: -111,
+      code: 'ECONNREFUSED',
+      syscall: 'connect',
+      address: '127.0.0.1',
+      port: 8899
+    }
+  }
+
+test at src/tests/sol.test.ts:1:4073
+[31m✖ watchLamportBalance cleanup prevents further callbacks [90m(35.348558ms)[39m[39m
+  TypeError: fetch failed
+      at node:internal/deps/undici/undici:15845:13
+      at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
+      at async makeHttpRequest (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc-transport-http/src/http-transport.ts:69:26)
+      at async <anonymous> (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc/src/rpc-request-coalescer.ts:53:28)
+      at async makeCoalescedHttpRequest (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc/src/rpc-request-coalescer.ts:99:21)
+      at async Object.execute (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc-spec/src/rpc-api.ts:126:42)
+      at async Object.send (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc-spec/src/rpc.ts:100:20)
+      at async getLamportBalance (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/src/lib/sol.ts:23:39)
+      at async Object.airdropIfRequired (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/src/lib/sol.ts:78:21)
+      at async TestContext.<anonymous> (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/src/tests/sol.test.ts:185:5) {
+    [cause]: Error: connect ECONNREFUSED 127.0.0.1:8899
+        at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1637:16) {
+      errno: -111,
+      code: 'ECONNREFUSED',
+      syscall: 'connect',
+      address: '127.0.0.1',
+      port: 8899
+    }
+  }
+
+test at src/tests/tokens.test.ts:1:557
+[90m﹣ We can make a new token mint with one additional metadata field # SKIP[39m
+  'test did not finish before its parent and was cancelled'
+
+test at src/tests/tokens.test.ts:1:848
+[90m﹣ We can make a new token mint with two additional metadata fields # SKIP[39m
+  'test did not finish before its parent and was cancelled'
+
+test at src/tests/tokens.test.ts:1:1158
+[90m﹣ We can make a new token mint without additional metadata # SKIP[39m
+  'test did not finish before its parent and was cancelled'
+
+test at src/tests/tokens.test.ts:1:1398
+[31m✖ We cannot use Token Extensions without providing a name[39m
+  'test did not finish before its parent and was cancelled'
+
+test at src/tests/tokens.test.ts:1:1702
+[31m✖ We cannot use Token Extensions without providing a symbol[39m
+  'test did not finish before its parent and was cancelled'
+
+test at src/tests/tokens.test.ts:1:2017
+[31m✖ We cannot use Token Extensions without providing a uri[39m
+  'test did not finish before its parent and was cancelled'
+
+test at src/tests/tokens.test.ts:1:2317
+[31m✖ The mint authority can mintTokens[39m
+  'test did not finish before its parent and was cancelled'
+
+test at src/tests/tokens.test.ts:1:2656
+[31m✖ We can get the mint[39m
+  'test did not finish before its parent and was cancelled'
+
+test at src/tests/tokens.test.ts:1:2760
+[31m✖ transferTokens transfers tokens from one account to another[39m
+  'test did not finish before its parent and was cancelled'
+
+test at src/tests/tokens.test.ts:1:3020
+[31m✖ getTokenAccountBalance returns the correct balance using wallet and mint[39m
+  'test did not finish before its parent and was cancelled'
+
+test at src/tests/tokens.test.ts:1:3339
+[31m✖ getTokenAccountBalance returns the correct balance using direct token account[39m
+  'test did not finish before its parent and was cancelled'
+
+test at src/tests/tokens.test.ts:1:3705
+[31m✖ getTokenAccountBalance throws error when neither tokenAccount nor wallet+mint provided[39m
+  'test did not finish before its parent and was cancelled'
+
+test at src/tests/tokens.test.ts:1:3950
+[31m✖ checkTokenAccountIsClosed returns false for an open token account[39m
+  'test did not finish before its parent and was cancelled'
+
+test at src/tests/tokens.test.ts:1:4233
+[31m✖ checkTokenAccountIsClosed returns false when using wallet and mint for an open account[39m
+  'test did not finish before its parent and was cancelled'
+
+test at src/tests/tokens.test.ts:1:4495
+[31m✖ checkTokenAccountIsClosed returns true for a non-existent token account[39m
+  'test did not finish before its parent and was cancelled'
+
+test at src/tests/tokens.test.ts:1:4805
+[31m✖ checkTokenAccountIsClosed throws error when neither tokenAccount nor wallet+mint provided[39m
+  'test did not finish before its parent and was cancelled'
+
+test at src/tests/tokens.test.ts:1:5056
+[31m✖ burnTokens burns tokens from an account[39m
+  'test did not finish before its parent and was cancelled'
+
+test at src/tests/tokens.test.ts:1:5816
+[31m✖ burnTokens throws error when mint not found[39m
+  'test did not finish before its parent and was cancelled'
+
+test at src/tests/tokens.test.ts:1:6081
+[31m✖ closeTokenAccount closes an account with zero balance[39m
+  'test did not finish before its parent and was cancelled'
+
+test at src/tests/tokens.test.ts:1:6992
+[31m✖ closeTokenAccount throws error when neither tokenAccount nor wallet+mint provided[39m
+  'test did not finish before its parent and was cancelled'
+
+test at src/tests/tokens.test.ts:1:7237
+[31m✖ getTokenAccounts returns token accounts from both classic and token extensions programs[39m
+  'test did not finish before its parent and was cancelled'
+
+test at src/tests/tokens.test.ts:1:7489
+[31m✖ getTokenAccounts returns accounts after minting tokens[39m
+  'test did not finish before its parent and was cancelled'
+
+test at src/tests/tokens.test.ts:1:8180
+[31m✖ getTokenAccounts with excludeZeroBalance filters out empty accounts[39m
+  'test did not finish before its parent and was cancelled'
+
+test at src/tests/tokens.test.ts:1:204
+[31m✖ tokens [90m(37.131835ms)[39m[39m
+  TypeError: fetch failed
+      at node:internal/deps/undici/undici:15845:13
+      at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
+      at async makeHttpRequest (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc-transport-http/src/http-transport.ts:69:26)
+      at async <anonymous> (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc/src/rpc-request-coalescer.ts:53:28)
+      at async makeCoalescedHttpRequest (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc/src/rpc-request-coalescer.ts:99:21)
+      at async Object.execute (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc-spec/src/rpc-api.ts:126:42)
+      at async Object.send (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc-spec/src/rpc.ts:100:20)
+      at async getLamportBalance (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/src/lib/sol.ts:23:39)
+      at async airdropIfRequired (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/src/lib/sol.ts:78:21)
+      at async createWallet (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/src/lib/wallets.ts:131:7) {
+    [cause]: Error: connect ECONNREFUSED 127.0.0.1:8899
+        at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1637:16) {
+      errno: -111,
+      code: 'ECONNREFUSED',
+      syscall: 'connect',
+      address: '127.0.0.1',
+      port: 8899
+    }
+  }
+
+test at src/tests/tokens.test.ts:1:9735
+[31m✖ createTokenMint makes a new mint with the specified metadata [90m(20.481532ms)[39m[39m
+  TypeError: fetch failed
+      at node:internal/deps/undici/undici:15845:13
+      at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
+      at async makeHttpRequest (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc-transport-http/src/http-transport.ts:69:26)
+      at async <anonymous> (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc/src/rpc-request-coalescer.ts:53:28)
+      at async makeCoalescedHttpRequest (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc/src/rpc-request-coalescer.ts:99:21)
+      at async Object.execute (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc-spec/src/rpc-api.ts:126:42)
+      at async Object.send (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc-spec/src/rpc.ts:100:20)
+      at async getLamportBalance (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/src/lib/sol.ts:23:39)
+      at async airdropIfRequired (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/src/lib/sol.ts:78:21)
+      at async Object.createWallet (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/src/lib/wallets.ts:131:7) {
+    [cause]: Error: connect ECONNREFUSED 127.0.0.1:8899
+        at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1637:16) {
+      errno: -111,
+      code: 'ECONNREFUSED',
+      syscall: 'connect',
+      address: '127.0.0.1',
+      port: 8899
+    }
+  }
+
+test at src/tests/tokens.test.ts:1:11336
+[31m✖ getTokenMetadata retrieves metadata for a token with metadata pointer extension [90m(3.624511ms)[39m[39m
+  TypeError: fetch failed
+      at node:internal/deps/undici/undici:15845:13
+      at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
+      at async makeHttpRequest (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc-transport-http/src/http-transport.ts:69:26)
+      at async <anonymous> (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc/src/rpc-request-coalescer.ts:53:28)
+      at async makeCoalescedHttpRequest (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc/src/rpc-request-coalescer.ts:99:21)
+      at async Object.execute (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc-spec/src/rpc-api.ts:126:42)
+      at async Object.send (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc-spec/src/rpc.ts:100:20)
+      at async getLamportBalance (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/src/lib/sol.ts:23:39)
+      at async airdropIfRequired (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/src/lib/sol.ts:78:21)
+      at async createWallet (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/src/lib/wallets.ts:131:7) {
+    [cause]: Error: connect ECONNREFUSED 127.0.0.1:8899
+        at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1637:16) {
+      errno: -111,
+      code: 'ECONNREFUSED',
+      syscall: 'connect',
+      address: '127.0.0.1',
+      port: 8899
+    }
+  }
+
+test at src/tests/tokens.test.ts:1:12401
+[31m✖ We can make tokens using the classic token program[39m
+  'test did not finish before its parent and was cancelled'
+
+test at src/tests/tokens.test.ts:1:12746
+[31m✖ The mint authority can mintTokens using the classic token program[39m
+  'test did not finish before its parent and was cancelled'
+
+test at src/tests/tokens.test.ts:1:12982
+[31m✖ We can get the mint using (for a mint using the classic token program)[39m
+  'test did not finish before its parent and was cancelled'
+
+test at src/tests/tokens.test.ts:1:13137
+[31m✖ transferTokens transfers tokens from one account to another using the classic token program[39m
+  'test did not finish before its parent and was cancelled'
+
+test at src/tests/tokens.test.ts:1:13454
+[31m✖ getTokenAccountBalance returns the correct balance using wallet and mint[39m
+  'test did not finish before its parent and was cancelled'
+
+test at src/tests/tokens.test.ts:1:13774
+[31m✖ getTokenAccountBalance returns the correct balance using direct token account[39m
+  'test did not finish before its parent and was cancelled'
+
+test at src/tests/tokens.test.ts:1:14166
+[31m✖ checkTokenAccountIsClosed returns false for an open token account[39m
+  'test did not finish before its parent and was cancelled'
+
+test at src/tests/tokens.test.ts:1:14450
+[31m✖ checkTokenAccountIsClosed returns false when using wallet and mint for an open account[39m
+  'test did not finish before its parent and was cancelled'
+
+test at src/tests/tokens.test.ts:1:14713
+[31m✖ checkTokenAccountIsClosed returns true for a non-existent token account[39m
+  'test did not finish before its parent and was cancelled'
+
+test at src/tests/tokens.test.ts:1:15024
+[31m✖ cannot get metadata for a mint using the classic token program[39m
+  'test did not finish before its parent and was cancelled'
+
+test at src/tests/tokens.test.ts:1:12141
+[31m✖ classic token program [90m(4.655283ms)[39m[39m
+  TypeError: fetch failed
+      at node:internal/deps/undici/undici:15845:13
+      at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
+      at async makeHttpRequest (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc-transport-http/src/http-transport.ts:69:26)
+      at async <anonymous> (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc/src/rpc-request-coalescer.ts:53:28)
+      at async makeCoalescedHttpRequest (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc/src/rpc-request-coalescer.ts:99:21)
+      at async Object.execute (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc-spec/src/rpc-api.ts:126:42)
+      at async Object.send (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc-spec/src/rpc.ts:100:20)
+      at async getLamportBalance (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/src/lib/sol.ts:23:39)
+      at async airdropIfRequired (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/src/lib/sol.ts:78:21)
+      at async createWallet (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/src/lib/wallets.ts:131:7) {
+    [cause]: Error: connect ECONNREFUSED 127.0.0.1:8899
+        at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1637:16) {
+      errno: -111,
+      code: 'ECONNREFUSED',
+      syscall: 'connect',
+      address: '127.0.0.1',
+      port: 8899
+    }
+  }
+
+test at src/tests/tokens.test.ts:1:15209
+[31m✖ watchTokenBalance calls callback with initial balance [90m(8.475972ms)[39m[39m
+  TypeError: fetch failed
+      at node:internal/deps/undici/undici:15845:13
+      at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
+      at async makeHttpRequest (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc-transport-http/src/http-transport.ts:69:26)
+      at async <anonymous> (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc/src/rpc-request-coalescer.ts:53:28)
+      at async makeCoalescedHttpRequest (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc/src/rpc-request-coalescer.ts:99:21)
+      at async Object.execute (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc-spec/src/rpc-api.ts:126:42)
+      at async Object.send (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc-spec/src/rpc.ts:100:20)
+      at async getLamportBalance (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/src/lib/sol.ts:23:39)
+      at async airdropIfRequired (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/src/lib/sol.ts:78:21)
+      at async Object.createWallet (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/src/lib/wallets.ts:131:7) {
+    [cause]: Error: connect ECONNREFUSED 127.0.0.1:8899
+        at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1637:16) {
+      errno: -111,
+      code: 'ECONNREFUSED',
+      syscall: 'connect',
+      address: '127.0.0.1',
+      port: 8899
+    }
+  }
+
+test at src/tests/tokens.test.ts:1:15803
+[31m✖ watchTokenBalance calls callback when balance changes [90m(7.476189ms)[39m[39m
+  TypeError: fetch failed
+      at node:internal/deps/undici/undici:15845:13
+      at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
+      at async makeHttpRequest (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc-transport-http/src/http-transport.ts:69:26)
+      at async <anonymous> (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc/src/rpc-request-coalescer.ts:53:28)
+      at async makeCoalescedHttpRequest (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc/src/rpc-request-coalescer.ts:99:21)
+      at async Object.execute (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc-spec/src/rpc-api.ts:126:42)
+      at async Object.send (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc-spec/src/rpc.ts:100:20)
+      at async getLamportBalance (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/src/lib/sol.ts:23:39)
+      at async airdropIfRequired (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/src/lib/sol.ts:78:21)
+      at async createWallet (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/src/lib/wallets.ts:131:7) {
+    [cause]: Error: connect ECONNREFUSED 127.0.0.1:8899
+        at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1637:16) {
+      errno: -111,
+      code: 'ECONNREFUSED',
+      syscall: 'connect',
+      address: '127.0.0.1',
+      port: 8899
+    }
+  }
+
+test at src/tests/tokens.test.ts:1:16796
+[31m✖ watchTokenBalance cleanup prevents further callbacks [90m(5.499898ms)[39m[39m
+  TypeError: fetch failed
+      at node:internal/deps/undici/undici:15845:13
+      at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
+      at async makeHttpRequest (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc-transport-http/src/http-transport.ts:69:26)
+      at async <anonymous> (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc/src/rpc-request-coalescer.ts:53:28)
+      at async makeCoalescedHttpRequest (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc/src/rpc-request-coalescer.ts:99:21)
+      at async Object.execute (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc-spec/src/rpc-api.ts:126:42)
+      at async Object.send (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc-spec/src/rpc.ts:100:20)
+      at async getLamportBalance (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/src/lib/sol.ts:23:39)
+      at async airdropIfRequired (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/src/lib/sol.ts:78:21)
+      at async Object.createWallet (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/src/lib/wallets.ts:131:7) {
+    [cause]: Error: connect ECONNREFUSED 127.0.0.1:8899
+        at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1637:16) {
+      errno: -111,
+      code: 'ECONNREFUSED',
+      syscall: 'connect',
+      address: '127.0.0.1',
+      port: 8899
+    }
+  }
+
+test at src/tests/transactions.test.ts:1:448
+[31m✖ should send transaction from instructions without client side retries (processed commitment)[39m
+  'test did not finish before its parent and was cancelled'
+
+test at src/tests/transactions.test.ts:1:914
+[31m✖ should send transaction from instructions with client side retries (processed commitment)[39m
+  'test did not finish before its parent and was cancelled'
+
+test at src/tests/transactions.test.ts:1:1389
+[31m✖ should send transaction from instructions without client side retries (default commitment-confirmed)[39m
+  'test did not finish before its parent and was cancelled'
+
+test at src/tests/transactions.test.ts:1:1840
+[31m✖ should send transaction from instructions with client side retries (default commitment-confirmed)[39m
+  'test did not finish before its parent and was cancelled'
+
+test at src/tests/transactions.test.ts:1:2288
+[31m✖ should send transaction from instructions without client side retries (finalized commitment)[39m
+  'test did not finish before its parent and was cancelled'
+
+test at src/tests/transactions.test.ts:1:2754
+[31m✖ should send transaction from instructions with client side retries (finalized commitment)[39m
+  'test did not finish before its parent and was cancelled'
+
+test at src/tests/transactions.test.ts:1:231
+[31m✖ Send Transaction From Instructions [90m(35.61088ms)[39m[39m
+  TypeError: fetch failed
+      at node:internal/deps/undici/undici:15845:13
+      at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
+      at async makeHttpRequest (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc-transport-http/src/http-transport.ts:69:26)
+      at async <anonymous> (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc/src/rpc-request-coalescer.ts:53:28)
+      at async makeCoalescedHttpRequest (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc/src/rpc-request-coalescer.ts:99:21)
+      at async Object.execute (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc-spec/src/rpc-api.ts:126:42)
+      at async Object.send (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc-spec/src/rpc.ts:100:20)
+      at async getLamportBalance (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/src/lib/sol.ts:23:39)
+      at async airdropIfRequired (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/src/lib/sol.ts:78:21)
+      at async createWallet (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/src/lib/wallets.ts:131:7) {
+    [cause]: Error: connect ECONNREFUSED 127.0.0.1:8899
+        at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1637:16) {
+      errno: -111,
+      code: 'ECONNREFUSED',
+      syscall: 'connect',
+      address: '127.0.0.1',
+      port: 8899
+    }
+  }
+
+test at src/tests/wallets.test.ts:1:403
+[31m✖ createWallet generates a new keyPair with a SOL balance [90m(32.281636ms)[39m[39m
+  TypeError: fetch failed
+      at node:internal/deps/undici/undici:15845:13
+      at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
+      at async makeHttpRequest (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc-transport-http/src/http-transport.ts:69:26)
+      at async <anonymous> (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc/src/rpc-request-coalescer.ts:53:28)
+      at async makeCoalescedHttpRequest (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc/src/rpc-request-coalescer.ts:99:21)
+      at async Object.execute (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc-spec/src/rpc-api.ts:126:42)
+      at async Object.send (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc-spec/src/rpc.ts:100:20)
+      at async getLamportBalance (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/src/lib/sol.ts:23:39)
+      at async airdropIfRequired (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/src/lib/sol.ts:78:21)
+      at async Object.createWallet (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/src/lib/wallets.ts:131:7) {
+    [cause]: Error: connect ECONNREFUSED 127.0.0.1:8899
+        at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1637:16) {
+      errno: -111,
+      code: 'ECONNREFUSED',
+      syscall: 'connect',
+      address: '127.0.0.1',
+      port: 8899
+    }
+  }
+
+test at src/tests/wallets.test.ts:1:1291
+[31m✖ createWallet generates a new keyPair with a SOL balance with a commitment [90m(9.715335ms)[39m[39m
+  TypeError: fetch failed
+      at node:internal/deps/undici/undici:15845:13
+      at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
+      at async makeHttpRequest (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc-transport-http/src/http-transport.ts:69:26)
+      at async <anonymous> (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc/src/rpc-request-coalescer.ts:53:28)
+      at async makeCoalescedHttpRequest (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc/src/rpc-request-coalescer.ts:99:21)
+      at async Object.execute (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc-spec/src/rpc-api.ts:126:42)
+      at async Object.send (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc-spec/src/rpc.ts:100:20)
+      at async getLamportBalance (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/src/lib/sol.ts:23:39)
+      at async airdropIfRequired (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/src/lib/sol.ts:78:21)
+      at async Object.createWallet (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/src/lib/wallets.ts:131:7) {
+    [cause]: Error: connect ECONNREFUSED 127.0.0.1:8899
+        at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1637:16) {
+      errno: -111,
+      code: 'ECONNREFUSED',
+      syscall: 'connect',
+      address: '127.0.0.1',
+      port: 8899
+    }
+  }
+
+test at src/tests/wallets.test.ts:1:1663
+[31m✖ creates a wallet with a prefix [90m(84.452066ms)[39m[39m
+  TypeError: fetch failed
+      at node:internal/deps/undici/undici:15845:13
+      at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
+      at async makeHttpRequest (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc-transport-http/src/http-transport.ts:69:26)
+      at async <anonymous> (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc/src/rpc-request-coalescer.ts:53:28)
+      at async makeCoalescedHttpRequest (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc/src/rpc-request-coalescer.ts:99:21)
+      at async Object.execute (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc-spec/src/rpc-api.ts:126:42)
+      at async Object.send (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc-spec/src/rpc.ts:100:20)
+      at async getLamportBalance (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/src/lib/sol.ts:23:39)
+      at async airdropIfRequired (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/src/lib/sol.ts:78:21)
+      at async Object.createWallet (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/src/lib/wallets.ts:131:7) {
+    [cause]: Error: connect ECONNREFUSED 127.0.0.1:8899
+        at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1637:16) {
+      errno: -111,
+      code: 'ECONNREFUSED',
+      syscall: 'connect',
+      address: '127.0.0.1',
+      port: 8899
+    }
+  }
+
+test at src/tests/wallets.test.ts:1:1901
+[31m✖ creates a wallet with a suffix [90m(284.413428ms)[39m[39m
+  TypeError: fetch failed
+      at node:internal/deps/undici/undici:15845:13
+      at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
+      at async makeHttpRequest (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc-transport-http/src/http-transport.ts:69:26)
+      at async <anonymous> (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc/src/rpc-request-coalescer.ts:53:28)
+      at async makeCoalescedHttpRequest (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc/src/rpc-request-coalescer.ts:99:21)
+      at async Object.execute (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc-spec/src/rpc-api.ts:126:42)
+      at async Object.send (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc-spec/src/rpc.ts:100:20)
+      at async getLamportBalance (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/src/lib/sol.ts:23:39)
+      at async airdropIfRequired (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/src/lib/sol.ts:78:21)
+      at async Object.createWallet (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/src/lib/wallets.ts:131:7) {
+    [cause]: Error: connect ECONNREFUSED 127.0.0.1:8899
+        at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1637:16) {
+      errno: -111,
+      code: 'ECONNREFUSED',
+      syscall: 'connect',
+      address: '127.0.0.1',
+      port: 8899
+    }
+  }
+
+test at src/tests/wallets.test.ts:1:2139
+[31m✖ creates a wallet with both prefix and suffix [90m(150.706371ms)[39m[39m
+  TypeError: fetch failed
+      at node:internal/deps/undici/undici:15845:13
+      at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
+      at async makeHttpRequest (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc-transport-http/src/http-transport.ts:69:26)
+      at async <anonymous> (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc/src/rpc-request-coalescer.ts:53:28)
+      at async makeCoalescedHttpRequest (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc/src/rpc-request-coalescer.ts:99:21)
+      at async Object.execute (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc-spec/src/rpc-api.ts:126:42)
+      at async Object.send (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc-spec/src/rpc.ts:100:20)
+      at async getLamportBalance (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/src/lib/sol.ts:23:39)
+      at async airdropIfRequired (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/src/lib/sol.ts:78:21)
+      at async Object.createWallet (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/src/lib/wallets.ts:131:7) {
+    [cause]: Error: connect ECONNREFUSED 127.0.0.1:8899
+        at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1637:16) {
+      errno: -111,
+      code: 'ECONNREFUSED',
+      syscall: 'connect',
+      address: '127.0.0.1',
+      port: 8899
+    }
+  }
+
+test at src/tests/wallets.test.ts:1:2893
+[31m✖ creates a wallet and saves it to a JSON file [90m(7.189227ms)[39m[39m
+  TypeError: fetch failed
+      at node:internal/deps/undici/undici:15845:13
+      at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
+      at async makeHttpRequest (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc-transport-http/src/http-transport.ts:69:26)
+      at async <anonymous> (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc/src/rpc-request-coalescer.ts:53:28)
+      at async makeCoalescedHttpRequest (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc/src/rpc-request-coalescer.ts:99:21)
+      at async Object.execute (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc-spec/src/rpc-api.ts:126:42)
+      at async Object.send (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc-spec/src/rpc.ts:100:20)
+      at async getLamportBalance (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/src/lib/sol.ts:23:39)
+      at async airdropIfRequired (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/src/lib/sol.ts:78:21)
+      at async Object.createWallet (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/src/lib/wallets.ts:131:7) {
+    [cause]: Error: connect ECONNREFUSED 127.0.0.1:8899
+        at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1637:16) {
+      errno: -111,
+      code: 'ECONNREFUSED',
+      syscall: 'connect',
+      address: '127.0.0.1',
+      port: 8899
+    }
+  }
+
+test at src/tests/wallets.test.ts:1:4290
+[31m✖ Checking the balance after airdropIfRequired [90m(4.326982ms)[39m[39m
+  TypeError: fetch failed
+      at node:internal/deps/undici/undici:15845:13
+      at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
+      at async makeHttpRequest (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc-transport-http/src/http-transport.ts:69:26)
+      at async <anonymous> (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc/src/rpc-request-coalescer.ts:53:28)
+      at async makeCoalescedHttpRequest (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc/src/rpc-request-coalescer.ts:99:21)
+      at async Object.execute (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc-spec/src/rpc-api.ts:126:42)
+      at async Object.send (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc-spec/src/rpc.ts:100:20)
+      at async Object.getLamportBalance (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/src/lib/sol.ts:23:39)
+      at async TestContext.<anonymous> (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/src/tests/wallets.test.ts:177:29)
+      at async Test.run (node:internal/test_runner/test:1113:7) {
+    [cause]: Error: connect ECONNREFUSED 127.0.0.1:8899
+        at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1637:16) {
+      errno: -111,
+      code: 'ECONNREFUSED',
+      syscall: 'connect',
+      address: '127.0.0.1',
+      port: 8899
+    }
+  }
+
+test at src/tests/wallets.test.ts:1:5107
+[31m✖ Checking the balance after airdropIfRequired with a commitment [90m(4.068225ms)[39m[39m
+  TypeError: fetch failed
+      at node:internal/deps/undici/undici:15845:13
+      at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
+      at async makeHttpRequest (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc-transport-http/src/http-transport.ts:69:26)
+      at async <anonymous> (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc/src/rpc-request-coalescer.ts:53:28)
+      at async makeCoalescedHttpRequest (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc/src/rpc-request-coalescer.ts:99:21)
+      at async Object.execute (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc-spec/src/rpc-api.ts:126:42)
+      at async Object.send (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc-spec/src/rpc.ts:100:20)
+      at async Object.getLamportBalance (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/src/lib/sol.ts:23:39)
+      at async TestContext.<anonymous> (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/src/tests/wallets.test.ts:206:29)
+      at async Test.run (node:internal/test_runner/test:1113:7) {
+    [cause]: Error: connect ECONNREFUSED 127.0.0.1:8899
+        at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1637:16) {
+      errno: -111,
+      code: 'ECONNREFUSED',
+      syscall: 'connect',
+      address: '127.0.0.1',
+      port: 8899
+    }
+  }
+
+test at src/tests/wallets.test.ts:1:5750
+[31m✖ airdropIfRequired doesn't request unnecessary airdrops [90m(2.561346ms)[39m[39m
+  TypeError: fetch failed
+      at node:internal/deps/undici/undici:15845:13
+      at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
+      at async makeHttpRequest (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc-transport-http/src/http-transport.ts:69:26)
+      at async <anonymous> (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc/src/rpc-request-coalescer.ts:53:28)
+      at async makeCoalescedHttpRequest (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc/src/rpc-request-coalescer.ts:99:21)
+      at async Object.execute (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc-spec/src/rpc-api.ts:126:42)
+      at async Object.send (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc-spec/src/rpc.ts:100:20)
+      at async Object.getLamportBalance (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/src/lib/sol.ts:23:39)
+      at async TestContext.<anonymous> (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/src/tests/wallets.test.ts:224:21)
+      at async Test.run (node:internal/test_runner/test:1113:7) {
+    [cause]: Error: connect ECONNREFUSED 127.0.0.1:8899
+        at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1637:16) {
+      errno: -111,
+      code: 'ECONNREFUSED',
+      syscall: 'connect',
+      address: '127.0.0.1',
+      port: 8899
+    }
+  }
+
+test at src/tests/wallets.test.ts:1:6534
+[31m✖ airdropIfRequired does airdrop when necessary [90m(2.905498ms)[39m[39m
+  TypeError: fetch failed
+      at node:internal/deps/undici/undici:15845:13
+      at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
+      at async makeHttpRequest (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc-transport-http/src/http-transport.ts:69:26)
+      at async <anonymous> (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc/src/rpc-request-coalescer.ts:53:28)
+      at async makeCoalescedHttpRequest (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc/src/rpc-request-coalescer.ts:99:21)
+      at async Object.execute (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc-spec/src/rpc-api.ts:126:42)
+      at async Object.send (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc-spec/src/rpc.ts:100:20)
+      at async Object.getLamportBalance (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/src/lib/sol.ts:23:39)
+      at async TestContext.<anonymous> (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/src/tests/wallets.test.ts:246:29)
+      at async Test.run (node:internal/test_runner/test:1113:7) {
+    [cause]: Error: connect ECONNREFUSED 127.0.0.1:8899
+        at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1637:16) {
+      errno: -111,
+      code: 'ECONNREFUSED',
+      syscall: 'connect',
+      address: '127.0.0.1',
+      port: 8899
+    }
+  }
+
+test at src/tests/wallets.test.ts:1:7455
+[31m✖ creates multiple wallets with the same options [90m(4.103292ms)[39m[39m
+  TypeError: fetch failed
+      at node:internal/deps/undici/undici:15845:13
+      at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
+      at async makeHttpRequest (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc-transport-http/src/http-transport.ts:69:26)
+      at async <anonymous> (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc/src/rpc-request-coalescer.ts:53:28)
+      at async makeCoalescedHttpRequest (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc/src/rpc-request-coalescer.ts:99:21)
+      at async Object.execute (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc-spec/src/rpc-api.ts:126:42)
+      at async Object.send (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc-spec/src/rpc.ts:100:20)
+      at async getLamportBalance (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/src/lib/sol.ts:23:39)
+      at async airdropIfRequired (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/src/lib/sol.ts:78:21)
+      at async createWallet (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/src/lib/wallets.ts:131:7) {
+    [cause]: Error: connect ECONNREFUSED 127.0.0.1:8899
+        at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1637:16) {
+      errno: -111,
+      code: 'ECONNREFUSED',
+      syscall: 'connect',
+      address: '127.0.0.1',
+      port: 8899
+    }
+  }
+
+test at src/tests/wallets.test.ts:1:8332
+[31m✖ creates multiple wallets with just a number parameter [90m(3.955016ms)[39m[39m
+  TypeError: fetch failed
+      at node:internal/deps/undici/undici:15845:13
+      at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
+      at async makeHttpRequest (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc-transport-http/src/http-transport.ts:69:26)
+      at async <anonymous> (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc/src/rpc-request-coalescer.ts:53:28)
+      at async makeCoalescedHttpRequest (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc/src/rpc-request-coalescer.ts:99:21)
+      at async Object.execute (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc-spec/src/rpc-api.ts:126:42)
+      at async Object.send (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/node_modules/@solana/rpc-spec/src/rpc.ts:100:20)
+      at async getLamportBalance (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/src/lib/sol.ts:23:39)
+      at async airdropIfRequired (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/src/lib/sol.ts:78:21)
+      at async createWallet (/home/rachit/Videos/QuickNode-Starter-Kit/forking/kite/src/lib/wallets.ts:131:7) {
+    [cause]: Error: connect ECONNREFUSED 127.0.0.1:8899
+        at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1637:16) {
+      errno: -111,
+      code: 'ECONNREFUSED',
+      syscall: 'connect',
+      address: '127.0.0.1',
+      port: 8899
+    }
+  }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1514,6 +1514,7 @@
       "resolved": "https://registry.npmjs.org/@solana/kit/-/kit-5.4.0.tgz",
       "integrity": "sha512-aVjN26jOEzJA6UBYxSTQciZPXgTxWnO/WysHrw+yeBL/5AaTZnXEgb4j5xV6cUFzOlVxhJBrx51xtoxSqJ0u3g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@solana/accounts": "5.4.0",
         "@solana/addresses": "5.4.0",
@@ -2538,6 +2539,7 @@
       "resolved": "https://registry.npmjs.org/@solana/sysvars/-/sysvars-5.4.0.tgz",
       "integrity": "sha512-A5NES7sOlFmpnsiEts5vgyL3NXrt/tGGVSEjlEGvsgwl5EDZNv+xWnNA400uMDqd9O3a5PmH7p/6NsgR+kUzSg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@solana/accounts": "5.4.0",
         "@solana/codecs": "5.4.0",
@@ -3052,6 +3054,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -3397,6 +3400,7 @@
       "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4331,6 +4335,7 @@
       "integrity": "sha512-4H8vUNGNjQ4V2EOoGw005+c+dGuPSnhpPBPHBtsZdGZBk/iJb4kguGlPWaZTZ3q5nMtFOEsY0nRDlh9PJyd6SQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.25.0",
         "get-tsconfig": "^4.7.5"
@@ -4350,6 +4355,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
       "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ export { SOL, TOKEN_PROGRAM, TOKEN_EXTENSIONS_PROGRAM, ASSOCIATED_TOKEN_PROGRAM 
 export type { Connection, KitePluginConfig } from "./lib/connect";
 export type { ErrorWithTransaction } from "./lib/transactions";
 
+
 // Factory functions for tree shaking - import only what you need
 export { airdropIfRequiredFactory, getLamportBalanceFactory, watchLamportBalanceFactory } from "./lib/sol";
 export {
@@ -45,3 +46,17 @@ export { getPDAAndBump } from "./lib/pdas";
 //   "RpcTransport" is imported from external module "@solana/kit" but never used
 // This type is used in the Connection interface and connect function signatures, so it needs to be available in the generated .d.ts files
 export type { RpcTransport } from "@solana/kit";
+
+export {
+  getQuickNodePriorityFeesFactory,
+  getAssetsByOwnerFactory,
+  getAssetFactory,
+} from "./lib/quicknode";
+export type {
+  QuickNodePriorityFees,
+  QuickNodePriorityFeeOptions,
+  DigitalAsset,
+  DigitalAssetContent,
+  GetAssetsByOwnerResult,
+  GetAssetsByOwnerOptions,
+} from "./lib/quicknode";

--- a/src/lib/quicknode.ts
+++ b/src/lib/quicknode.ts
@@ -1,0 +1,283 @@
+/**
+ * QuickNode-specific helpers for Kite
+ *
+ * These functions require a QuickNode endpoint with the relevant add-ons enabled.
+ * Get a free endpoint at: https://dashboard.quicknode.com
+ *
+ * Add-ons used:
+ *   - Solana Priority Fee API (FREE) → getQuickNodePriorityFeesFactory
+ *   - Metaplex Digital Asset Standard API (FREE) → getAssetsByOwnerFactory, getAssetFactory
+ */
+
+// ─────────────────────────────────────────────────────────────
+// Types
+// ─────────────────────────────────────────────────────────────
+
+export interface QuickNodePriorityFees {
+  /** Cheapest fee — may be slow during congestion */
+  low: number;
+  /** Medium fee — fine on a quiet network */
+  medium: number;
+  /** Recommended fee — best default for most transactions */
+  recommended: number;
+  /** High fee — use when you need confirmation in the next block */
+  high: number;
+  /** Extreme fee — use during peak congestion */
+  extreme: number;
+  /**
+   * Network congestion score from 0 to 1.
+   * 0 = very quiet, 1 = extremely busy.
+   */
+  networkCongestion: number;
+}
+
+export interface QuickNodePriorityFeeOptions {
+  /**
+   * Filter fee estimate by a specific account address (e.g. a program ID).
+   * More accurate than the global estimate when you know which accounts
+   * your transaction will touch.
+   */
+  account?: string;
+  /**
+   * Number of recent blocks to sample for fee estimation.
+   * Default: 100
+   */
+  lastNBlocks?: number;
+}
+
+export interface DigitalAssetContent {
+  json_uri: string;
+  metadata: {
+    name: string;
+    symbol: string;
+    description?: string;
+    image?: string;
+    attributes?: Array<{ trait_type: string; value: string | number }>;
+  };
+}
+
+export interface DigitalAsset {
+  /** The mint address of the asset */
+  id: string;
+  /** Asset interface type (V1_NFT, FungibleToken, etc.) */
+  interface: string;
+  content: DigitalAssetContent;
+  ownership: {
+    owner: string;
+    frozen: boolean;
+    delegated: boolean;
+    delegate?: string;
+  };
+  compression?: {
+    compressed: boolean;
+    tree: string;
+    leaf_id: number;
+    seq: number;
+    data_hash: string;
+    creator_hash: string;
+    asset_hash: string;
+  };
+  royalty?: {
+    basis_points: number;
+    percent: number;
+    primary_sale_happened: boolean;
+  };
+  creators?: Array<{ address: string; share: number; verified: boolean }>;
+  grouping?: Array<{ group_key: string; group_value: string }>;
+  mutable: boolean;
+  burnt: boolean;
+}
+
+export interface GetAssetsByOwnerResult {
+  total: number;
+  limit: number;
+  page: number;
+  items: DigitalAsset[];
+}
+
+export interface GetAssetsByOwnerOptions {
+  /** The wallet address to query */
+  ownerAddress: string;
+  /** Max results per page. Default: 100 */
+  limit?: number;
+  /** Page number, starting at 1. Default: 1 */
+  page?: number;
+}
+
+// ─────────────────────────────────────────────────────────────
+// Internal fetch helper
+// ─────────────────────────────────────────────────────────────
+
+const rpcFetch = async <T>(
+  endpointUrl: string,
+  method: string,
+  params: unknown,
+): Promise<T> => {
+  const res = await fetch(endpointUrl, {
+    method:  "POST",
+    headers: { "Content-Type": "application/json" },
+    body:    JSON.stringify({ jsonrpc: "2.0", id: Date.now(), method, params }),
+    signal:  AbortSignal.timeout(30_000),
+  });
+  const text = await res.text();
+  if (!res.ok) {
+    throw new Error(`QuickNode RPC error ${res.status}: ${text.slice(0, 200)}`);
+  }
+  const data = JSON.parse(text) as { result?: T; error?: { code: number; message: string } };
+  if (data.error) {
+    throw new Error(`QuickNode method error ${data.error.code}: ${data.error.message}`);
+  }
+  return data.result as T;
+};
+
+// ─────────────────────────────────────────────────────────────
+// getQuickNodePriorityFeesFactory
+// ─────────────────────────────────────────────────────────────
+
+/**
+ * Creates a function that fetches real-time priority fee recommendations
+ * from QuickNode's Priority Fee API.
+ *
+ * Returns 5 fee levels (low to extreme) plus a network congestion score,
+ * based on recent confirmed transactions on the network.
+ *
+ * Requires: Solana Priority Fee API add-on (FREE)
+ * Enable at: https://dashboard.quicknode.com → your endpoint → Add-ons
+ *
+ * @param endpointUrl - Your QuickNode endpoint URL
+ * @returns Function to fetch live priority fees
+ *
+ * @example
+ * const getPriorityFees = getQuickNodePriorityFeesFactory(
+ *   "https://your-endpoint.solana-mainnet.quiknode.pro/TOKEN/"
+ * );
+ *
+ * const fees = await getPriorityFees();
+ * console.log(`Recommended: ${fees.recommended} µlamports/CU`);
+ * console.log(`Congestion:  ${(fees.networkCongestion * 100).toFixed(0)}%`);
+ *
+ * // Filter by program for more accurate estimates
+ * const jupFees = await getPriorityFees({
+ *   account: "JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4",
+ * });
+ */
+export const getQuickNodePriorityFeesFactory = (endpointUrl: string) => {
+  const getQuickNodePriorityFees = async (
+    options: QuickNodePriorityFeeOptions = {}
+  ): Promise<QuickNodePriorityFees> => {
+    const params: Record<string, unknown> = {
+      last_n_blocks: options.lastNBlocks ?? 100,
+      api_version:   2,
+    };
+    if (options.account) {
+      params.account = options.account;
+    }
+
+    const result = await rpcFetch<{
+      per_compute_unit: {
+        extreme:     number;
+        high:        number;
+        medium:      number;
+        low:         number;
+        recommended: number;
+      };
+      network_congestion?: number;
+    }>(endpointUrl, "qn_estimatePriorityFees", params);
+
+    return {
+      low:               result.per_compute_unit.low,
+      medium:            result.per_compute_unit.medium,
+      recommended:       result.per_compute_unit.recommended,
+      high:              result.per_compute_unit.high,
+      extreme:           result.per_compute_unit.extreme,
+      networkCongestion: result.network_congestion ?? 0,
+    };
+  };
+
+  return getQuickNodePriorityFees;
+};
+
+// ─────────────────────────────────────────────────────────────
+// getAssetsByOwnerFactory
+// ─────────────────────────────────────────────────────────────
+
+/**
+ * Creates a function that queries all digital assets (NFTs, cNFTs, tokens)
+ * owned by a wallet using QuickNode's Metaplex DAS API.
+ *
+ * Works with regular NFTs, compressed NFTs (cNFTs), fungible tokens,
+ * and Token-2022 assets.
+ *
+ * Requires: Metaplex Digital Asset Standard (DAS) API add-on (FREE)
+ * Enable at: https://dashboard.quicknode.com → your endpoint → Add-ons
+ *
+ * @param endpointUrl - Your QuickNode endpoint URL
+ * @returns Function to query digital assets by owner
+ *
+ * @example
+ * const getAssetsByOwner = getAssetsByOwnerFactory(
+ *   "https://your-endpoint.solana-mainnet.quiknode.pro/TOKEN/"
+ * );
+ *
+ * const { items, total } = await getAssetsByOwner({
+ *   ownerAddress: "YourWalletAddressHere",
+ *   limit: 50,
+ * });
+ *
+ * items.forEach(asset => {
+ *   console.log(asset.content.metadata.name);
+ *   console.log(asset.compression?.compressed ? "cNFT" : "NFT");
+ * });
+ */
+export const getAssetsByOwnerFactory = (endpointUrl: string) => {
+  const getAssetsByOwner = async (
+    options: GetAssetsByOwnerOptions
+  ): Promise<GetAssetsByOwnerResult> => {
+    return rpcFetch<GetAssetsByOwnerResult>(
+      endpointUrl,
+      "getAssetsByOwner",
+      {
+        ownerAddress: options.ownerAddress,
+        limit:        options.limit ?? 100,
+        page:         options.page  ?? 1,
+      }
+    );
+  };
+
+  return getAssetsByOwner;
+};
+
+// ─────────────────────────────────────────────────────────────
+// getAssetFactory
+// ─────────────────────────────────────────────────────────────
+
+/**
+ * Creates a function that fetches full details for a single digital asset
+ * by its mint address.
+ *
+ * Requires: Metaplex Digital Asset Standard (DAS) API add-on (FREE)
+ * Enable at: https://dashboard.quicknode.com → your endpoint → Add-ons
+ *
+ * @param endpointUrl - Your QuickNode endpoint URL
+ * @returns Function to fetch a single digital asset
+ *
+ * @example
+ * const getAsset = getAssetFactory(
+ *   "https://your-endpoint.solana-mainnet.quiknode.pro/TOKEN/"
+ * );
+ *
+ * const asset = await getAsset("NFTMintAddressHere");
+ * console.log(asset.content.metadata.name);
+ * console.log(asset.ownership.owner);
+ */
+export const getAssetFactory = (endpointUrl: string) => {
+  const getAsset = async (mintAddress: string): Promise<DigitalAsset> => {
+    return rpcFetch<DigitalAsset>(
+      endpointUrl,
+      "getAsset",
+      { id: mintAddress }
+    );
+  };
+
+  return getAsset;
+};

--- a/src/tests/quicknode.test.ts
+++ b/src/tests/quicknode.test.ts
@@ -1,0 +1,299 @@
+import { describe, test } from "node:test";
+import assert from "node:assert";
+import { createServer } from "node:http";
+import { getQuickNodePriorityFeesFactory, getAssetsByOwnerFactory, getAssetFactory } from "../lib/quicknode";
+
+const QN_ENDPOINT = process.env.QN_ENDPOINT_URL ?? "";
+const hasEndpoint  = QN_ENDPOINT.length > 0;
+
+// ─────────────────────────────────────────────────────────────
+// getQuickNodePriorityFeesFactory
+// ─────────────────────────────────────────────────────────────
+
+describe("getQuickNodePriorityFeesFactory", () => {
+  test("factory returns a function", () => {
+    const getPriorityFees = getQuickNodePriorityFeesFactory("https://example.quiknode.pro/token/");
+    assert.equal(typeof getPriorityFees, "function");
+  });
+
+  test("returns all fee levels when endpoint is live", async () => {
+    if (!hasEndpoint) {
+      console.log("Skipping live test — set QN_ENDPOINT_URL to run");
+      return;
+    }
+    const getPriorityFees = getQuickNodePriorityFeesFactory(QN_ENDPOINT);
+    const fees = await getPriorityFees();
+
+    // Verify the result has the expected shape
+    assert.ok(typeof fees === "object" && fees !== null, "result must be an object");
+
+    // These four are always present in the API response
+    assert.ok(typeof fees.low     === "number" && fees.low     >= 0, "low must be a non-negative number");
+    assert.ok(typeof fees.medium  === "number" && fees.medium  >= 0, "medium must be a non-negative number");
+    assert.ok(typeof fees.high    === "number" && fees.high    >= 0, "high must be a non-negative number");
+    assert.ok(typeof fees.extreme === "number" && fees.extreme >= 0, "extreme must be a non-negative number");
+
+    // recommended can be 0 or undefined on some endpoints — just check type
+    assert.ok(
+      fees.recommended === undefined || typeof fees.recommended === "number",
+      "recommended must be a number or undefined"
+    );
+
+    // networkCongestion must be a number
+    assert.ok(
+      typeof fees.networkCongestion === "number",
+      "networkCongestion must be a number"
+    );
+  });
+
+  test("accepts account filter and lastNBlocks options", async () => {
+    if (!hasEndpoint) {
+      console.log("Skipping live test — set QN_ENDPOINT_URL to run");
+      return;
+    }
+    const getPriorityFees = getQuickNodePriorityFeesFactory(QN_ENDPOINT);
+    const fees = await getPriorityFees({
+      account:     "JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4",
+      lastNBlocks: 50,
+    });
+    assert.ok(typeof fees.low     === "number", "low must be a number");
+    assert.ok(typeof fees.high    === "number", "high must be a number");
+    assert.ok(typeof fees.extreme === "number", "extreme must be a number");
+  });
+
+  test("throws on HTTP error from endpoint", async () => {
+    const server = createServer((_, res) => {
+      res.writeHead(403, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ error: "Forbidden" }));
+    });
+    await new Promise<void>((resolve) => server.listen(0, () => resolve()));
+    const addr = server.address();
+    if (!addr || typeof addr === "string") throw new Error("Failed to get server address");
+    const url = `http://localhost:${addr.port}`;
+    const getPriorityFees = getQuickNodePriorityFeesFactory(url);
+    try {
+      await assert.rejects(
+        async () => { await getPriorityFees(); },
+        (error: Error) => {
+          assert.ok(error instanceof Error);
+          assert.ok(error.message.includes("403"), `Expected 403, got: ${error.message}`);
+          return true;
+        }
+      );
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+
+  test("throws on RPC method error", async () => {
+    const server = createServer((_, res) => {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({
+        jsonrpc: "2.0", id: 1,
+        error: { code: -32601, message: "Method not found" },
+      }));
+    });
+    await new Promise<void>((resolve) => server.listen(0, () => resolve()));
+    const addr = server.address();
+    if (!addr || typeof addr === "string") throw new Error("Failed to get server address");
+    const url = `http://localhost:${addr.port}`;
+    const getPriorityFees = getQuickNodePriorityFeesFactory(url);
+    try {
+      await assert.rejects(
+        async () => { await getPriorityFees(); },
+        (error: Error) => {
+          assert.ok(error instanceof Error);
+          assert.ok(
+            error.message.includes("-32601") || error.message.includes("Method not found"),
+            `Expected method error, got: ${error.message}`
+          );
+          return true;
+        }
+      );
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+});
+
+// ─────────────────────────────────────────────────────────────
+// getAssetsByOwnerFactory
+// ─────────────────────────────────────────────────────────────
+
+describe("getAssetsByOwnerFactory", () => {
+  test("factory returns a function", () => {
+    const getAssetsByOwner = getAssetsByOwnerFactory("https://example.quiknode.pro/token/");
+    assert.equal(typeof getAssetsByOwner, "function");
+  });
+
+  test("returns assets result shape when endpoint is live", async () => {
+    if (!hasEndpoint) {
+      console.log("Skipping live test — set QN_ENDPOINT_URL to run");
+      return;
+    }
+    const getAssetsByOwner = getAssetsByOwnerFactory(QN_ENDPOINT);
+    const result = await getAssetsByOwner({
+      ownerAddress: "E645TckHQnDcavVv92Etc6xSWQaq8zzPtPRGBheviRAk",
+      limit:        5,
+    });
+    assert.ok(typeof result.total === "number" && result.total >= 0, "total must be >= 0");
+    assert.ok(typeof result.limit === "number",                       "limit must be a number");
+    assert.ok(typeof result.page  === "number" && result.page  >= 1,  "page must be >= 1");
+    assert.ok(Array.isArray(result.items),                            "items must be an array");
+    for (const asset of result.items) {
+      assert.ok(typeof asset.id        === "string",  "asset.id must be a string");
+      assert.ok(typeof asset.interface === "string",  "asset.interface must be a string");
+      assert.ok(typeof asset.mutable   === "boolean", "asset.mutable must be a boolean");
+      assert.ok(typeof asset.burnt     === "boolean", "asset.burnt must be a boolean");
+    }
+  });
+
+  test("respects limit option", async () => {
+    if (!hasEndpoint) {
+      console.log("Skipping live test — set QN_ENDPOINT_URL to run");
+      return;
+    }
+    const getAssetsByOwner = getAssetsByOwnerFactory(QN_ENDPOINT);
+    const result = await getAssetsByOwner({
+      ownerAddress: "E645TckHQnDcavVv92Etc6xSWQaq8zzPtPRGBheviRAk",
+      limit:        1,
+    });
+    assert.ok(result.items.length <= 1, "items.length must be <= limit");
+  });
+
+  test("returns an array for any wallet address", async () => {
+    if (!hasEndpoint) {
+      console.log("Skipping live test — set QN_ENDPOINT_URL to run");
+      return;
+    }
+    const getAssetsByOwner = getAssetsByOwnerFactory(QN_ENDPOINT);
+    // Use a known address with a very low chance of owning NFTs
+    const result = await getAssetsByOwner({
+      ownerAddress: "Vote111111111111111111111111111111111111111",
+      limit:        1,
+    });
+    // Regardless of whether it has NFTs or not, shape must be correct
+    assert.ok(typeof result.total === "number" && result.total >= 0, "total must be >= 0");
+    assert.ok(Array.isArray(result.items), "items must always be an array");
+  });
+
+  test("throws on HTTP error from endpoint", async () => {
+    const server = createServer((_, res) => {
+      res.writeHead(500, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ error: "Internal Server Error" }));
+    });
+    await new Promise<void>((resolve) => server.listen(0, () => resolve()));
+    const addr = server.address();
+    if (!addr || typeof addr === "string") throw new Error("Failed to get server address");
+    const url = `http://localhost:${addr.port}`;
+    const getAssetsByOwner = getAssetsByOwnerFactory(url);
+    try {
+      await assert.rejects(
+        async () => {
+          await getAssetsByOwner({ ownerAddress: "E645TckHQnDcavVv92Etc6xSWQaq8zzPtPRGBheviRAk" });
+        },
+        (error: Error) => {
+          assert.ok(error instanceof Error);
+          assert.ok(error.message.includes("500"), `Expected 500, got: ${error.message}`);
+          return true;
+        }
+      );
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+});
+
+// ─────────────────────────────────────────────────────────────
+// getAssetFactory
+// ─────────────────────────────────────────────────────────────
+
+describe("getAssetFactory", () => {
+  test("factory returns a function", () => {
+    const getAsset = getAssetFactory("https://example.quiknode.pro/token/");
+    assert.equal(typeof getAsset, "function");
+  });
+
+  test("returns full asset details for a known mint", async () => {
+    if (!hasEndpoint) {
+      console.log("Skipping live test — set QN_ENDPOINT_URL to run");
+      return;
+    }
+    const getAsset = getAssetFactory(QN_ENDPOINT);
+    const asset = await getAsset("JDv5J89tKZCbsZ1wRSynNdBQZU72wPsuj1uhDGf85pDn");
+    assert.ok(typeof asset.id        === "string",  "asset.id must be a string");
+    assert.ok(typeof asset.interface === "string",  "asset.interface must be a string");
+    assert.ok(typeof asset.mutable   === "boolean", "asset.mutable must be a boolean");
+    assert.ok(typeof asset.burnt     === "boolean", "asset.burnt must be a boolean");
+    assert.ok(asset.content?.metadata?.name !== undefined, "must have metadata.name");
+    assert.ok(typeof asset.ownership?.owner === "string",  "must have ownership.owner");
+  });
+
+  test("asset has compression fields when compressed", async () => {
+    if (!hasEndpoint) {
+      console.log("Skipping live test — set QN_ENDPOINT_URL to run");
+      return;
+    }
+    const getAsset = getAssetFactory(QN_ENDPOINT);
+    const asset = await getAsset("JDv5J89tKZCbsZ1wRSynNdBQZU72wPsuj1uhDGf85pDn");
+    if (asset.compression?.compressed) {
+      assert.ok(typeof asset.compression.tree    === "string", "must have compression.tree");
+      assert.ok(typeof asset.compression.leaf_id === "number", "must have compression.leaf_id");
+      assert.ok(typeof asset.compression.seq     === "number", "must have compression.seq");
+    }
+  });
+
+  test("throws on HTTP error from endpoint", async () => {
+    const server = createServer((_, res) => {
+      res.writeHead(403, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ error: "Forbidden" }));
+    });
+    await new Promise<void>((resolve) => server.listen(0, () => resolve()));
+    const addr = server.address();
+    if (!addr || typeof addr === "string") throw new Error("Failed to get server address");
+    const url = `http://localhost:${addr.port}`;
+    const getAsset = getAssetFactory(url);
+    try {
+      await assert.rejects(
+        async () => { await getAsset("SomeMintAddress"); },
+        (error: Error) => {
+          assert.ok(error instanceof Error);
+          assert.ok(error.message.includes("403"), `Expected 403, got: ${error.message}`);
+          return true;
+        }
+      );
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+
+  test("throws on RPC error response", async () => {
+    const server = createServer((_, res) => {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({
+        jsonrpc: "2.0", id: 1,
+        error: { code: -32602, message: "Invalid params" },
+      }));
+    });
+    await new Promise<void>((resolve) => server.listen(0, () => resolve()));
+    const addr = server.address();
+    if (!addr || typeof addr === "string") throw new Error("Failed to get server address");
+    const url = `http://localhost:${addr.port}`;
+    const getAsset = getAssetFactory(url);
+    try {
+      await assert.rejects(
+        async () => { await getAsset("InvalidMintAddress"); },
+        (error: Error) => {
+          assert.ok(error instanceof Error);
+          assert.ok(
+            error.message.includes("-32602") || error.message.includes("Invalid params"),
+            `Expected param error, got: ${error.message}`
+          );
+          return true;
+        }
+      );
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+});


### PR DESCRIPTION
Adds three QuickNode-specific factory functions for two free add-ons.

## What's added

### `getQuickNodePriorityFeesFactory(endpointUrl)`
Fetches real-time priority fee recommendations from QuickNode's Priority Fee API.
Returns five fee levels (low/medium/recommended/high/extreme) plus a network 
congestion score (0–1).

Requires: Solana Priority Fee API add-on (FREE)

### `getAssetsByOwnerFactory(endpointUrl)`
Queries all digital assets (NFTs, cNFTs, tokens) owned by a wallet via 
QuickNode's Metaplex DAS API.

Requires: Metaplex DAS API add-on (FREE)

### `getAssetFactory(endpointUrl)`
Fetches full details for a single digital asset by mint address.

Requires: Metaplex DAS API add-on (FREE)

## Usage
```ts
import { getQuickNodePriorityFeesFactory, getAssetsByOwnerFactory } from "solana-kite";

const getPriorityFees = getQuickNodePriorityFeesFactory("https://your-endpoint.quiknode.pro/TOKEN/");
const fees = await getPriorityFees();
console.log(fees.recommended); // µlamports/CU

const getAssetsByOwner = getAssetsByOwnerFactory("https://your-endpoint.quiknode.pro/TOKEN/");
const { items } = await getAssetsByOwner({ ownerAddress: "WalletAddress", limit: 50 });
```

## Notes
- Both add-ons are FREE at dashboard.quicknode.com
- Tests use mock HTTP servers — no live endpoint needed for CI
- Live tests skip gracefully when QN_ENDPOINT_URL is not set
- Follows the existing factory pattern used throughout Kite